### PR TITLE
SLING-10954 Update Models Integration Tests to Sling 11 and Parent 46

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,7 @@
+Sling-Test-Regexp: .*Test
+
+Import-Package:\
+  org.apache.commons.beanutils;resolution:=optional,\
+  *
+
+-plugin: org.apache.sling.bnd.models.ModelsScannerPlugin

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,18 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.clients</artifactId>
+            <version>2.0.12</version>
+            <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+              </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.junit.teleporter</artifactId>
             <version>1.0.20</version>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.sling</groupId>
-        <artifactId>sling</artifactId>
-        <version>26</version>
+        <artifactId>sling-bundle-parent</artifactId>
+        <version>46</version>
         <relativePath/>
     </parent>
 
     <artifactId>org.apache.sling.models.integration-tests</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <packaging>bundle</packaging>
 
     <name>Apache Sling Models Integration Tests</name>
     <description>
@@ -38,121 +37,33 @@
         remote test proxy that runs in the integration-tests phase.
     </description>
     
-    <!-- 
-        To keep the instance under test running and run individual tests
-        against it, use:
-        
-            mvn clean verify -DkeepJarRunning=true -Dhttp.port=8080
-            
-        optionally using jar.executor.vm.options to enable remote debugging,
-        and in another console:
-        
-            mvn -o verify -Dtests.to.run=**/**Test.java -Dtest.server.url=http://localhost:8080
-            
-        optionally using -Dmaven.surefire.debug to enable debugging.            
-     -->
     <properties>
-        <sling.java.version>7</sling.java.version>
-        <!-- Set this to run the server on a specific port
-        <http.port></http.port>
-         -->
-         
-        <!-- Set this to run tests against an existing server instance -->
-        <keepJarRunning>false</keepJarRunning>
-        
-        <!-- URL of a server against which to run tests -->
-        <test.server.url />
-        
-         <!-- Set this to run tests against a specific hostname, if test.server.url is not set-->
-         <test.server.hostname />
-
-        <!-- Set this to use a different username for remote execution of sling junit tests -->
-        <test.server.username />
-
-        <!-- Set this to use a different password for remote execution of sling junit tests -->
-        <test.server.password />
-        
-        <!-- Options for the VM that executes our runnable jar -->
-        <jar.executor.vm.options>-Xmx512m</jar.executor.vm.options>
-        <!-- Alternative with JVM debug port
-        <jar.executor.vm.options>-Xmx512m -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=38080,suspend=n</jar.executor.vm.options>
-        -->
-        
-        <!-- Change this to use longer or shorter timeouts for testing -->
-        <sling.testing.timeout.multiplier>1.0</sling.testing.timeout.multiplier>
-        
-        <!-- Set this to run the executable jar in a specified filesystem folder -->
-        <jar.executor.work.folder />
-        
-        <!-- Options for the jar to execute. $JAREXEC_SERVER_PORT$ is replaced by the
-            selected port number -->
-        <jar.executor.jar.options>-p $JAREXEC_SERVER_PORT$</jar.executor.jar.options>
+        <sling.java.version>8</sling.java.version>
+        <!-- start with -DkeepITServerRunning=true to allow to rerun ITs or inspect the server after the ITs have been executed there -->
+        <keepITServerRunning>false</keepITServerRunning>
+        <project.build.outputTimestamp>2021-12-01T00:00:00Z</project.build.outputTimestamp>
     </properties>
 
     <build>
         <plugins>
-           <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${basedir}</directory>
-                            <includes>
-                                <!-- sling folder is the workdir of the executable jar that we test -->
-                                <include>sling/**</include>
-                            </includes>
-                        </fileset>
-                    </filesets>
-                </configuration>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.sling</groupId>
+                        <artifactId>org.apache.sling.bnd.models</artifactId>
+                        <version>1.0.0</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <extensions>true</extensions>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-baseline-maven-plugin</artifactId>
                 <configuration>
-                    <instructions>
-                        <Sling-Model-Packages>
-                            org.apache.sling.models.it.nonexisting,
-                            org.apache.sling.models.it.noclasses,
-                            org.apache.sling.models.it.models,
-                            org.apache.sling.models.it.rtbound,
-                            org.apache.sling.models.it.rtboundpicker,
-                            org.apache.sling.models.it.delegate.request,
-                            org.apache.sling.models.it.delegate.resource
-                        </Sling-Model-Packages>
-                        <Sling-Model-Classes>
-                            org.apache.sling.models.it.exporter.BaseComponent,
-                            org.apache.sling.models.it.exporter.ComponentImpl,
-                            org.apache.sling.models.it.exporter.ExtendedComponent,
-                            org.apache.sling.models.it.exporter.BaseRequestComponent,
-                            org.apache.sling.models.it.exporter.RequestComponentImpl,
-                            org.apache.sling.models.it.exporter.ExtendedRequestComponent,
-                            org.apache.sling.models.it.exporter.DoubledFirstComponent,
-                            org.apache.sling.models.it.exporter.DoubledSecondComponent
-                        </Sling-Model-Classes>
-                        <Sling-Test-Regexp>.*Test</Sling-Test-Regexp>
-                        <Export-Package>
-                            org.apache.sling.models.it.delegate.request,
-                            org.apache.sling.models.it.delegate.resource,
-                            org.apache.sling.models.it.exporter,
-                            org.apache.sling.models.it.implpicker,
-                            org.apache.sling.models.it.models,
-                            org.apache.sling.models.it.models.implextend,
-                            org.apache.sling.models.it.rtbound,
-                            org.apache.sling.models.it.rtboundpicker,
-                            org.apache.sling.models.it.services
-                        </Export-Package>
-                        <Import-Package>
-                            org.apache.commons.beanutils;resolution:=optional,
-                            *
-                        </Import-Package>
-                    </instructions>
+                    <skip>true</skip>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-            </plugin>
+           </plugin>
            <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
@@ -165,43 +76,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-runnable-jar</id>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                            <phase>process-resources</phase>
-                        <configuration>
-                            <includeArtifactIds>org.apache.sling.launchpad</includeArtifactIds>
-                            <excludeTransitive>true</excludeTransitive>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!-- 
-                            Consider all dependencies as candidates to be installed
-                            as additional bundles. We use system properties to define
-                            which bundles to install in which order.  
-                        -->
-                        <id>copy-additional-bundles</id>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                            <phase>process-resources</phase>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
-                            <excludeTransitive>true</excludeTransitive>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <!-- Find free ports to run our server -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -211,9 +85,10 @@
                         <goals>
                             <goal>reserve-network-port</goal>
                         </goals>
-                        <phase>process-resources</phase>
+                        <phase>pre-integration-test</phase>
                         <configuration>
                             <portNames>
+                                <!-- reserved port must be stored in property because it must be passed to the slingstart-maven-plugin -->
                                 <portName>http.port</portName>
                             </portNames>
                         </configuration>
@@ -221,61 +96,82 @@
                 </executions>
             </plugin>
             <plugin>
+                <!-- the Sling instance is provisioned from the model in src/main/provisioning/model.txt -->
+                <groupId>org.apache.sling</groupId>
+                <artifactId>slingstart-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>prepare-launchpad-package</id>
+                        <goals>
+                            <goal>prepare-package</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                    </execution>
+                    <execution>
+                        <id>build-launchpad-package</id>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <attachArtifact>false</attachArtifact>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>start-container-before-IT</id>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-container-after-IT</id>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                        <configuration>
+                            <shouldBlockUntilKeyIsPressed>${keepITServerRunning}</shouldBlockUntilKeyIsPressed>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <servers>
+                        <!-- this configuration applies to both 'start' and 'stop' -->
+                        <server>
+                            <id>singleinstance</id>
+                            <port>${http.port}</port>
+                            <vmOpts>${sling.vm.options}</vmOpts>
+                            <stdOutFile>sling/logs/stdout.log</stdOutFile>
+                        </server>
+                    </servers>
+                    <!-- this configuration only applies to 'prepare-package' and 'package' -->
+                    <disableExtendingMavenClasspath>true</disableExtendingMavenClasspath>
+                    <usePomDependencies>true</usePomDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>integration-test</id>
                         <goals>
                             <goal>integration-test</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>verify</id>
-                        <goals>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <systemProperties>
+                                <http.port>${http.port}</http.port>
+                            </systemProperties>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
-                    <debugForkedProcess>${maven.surefire.debug}</debugForkedProcess>
                     <systemPropertyVariables>
-                        <test.server.url>${test.server.url}</test.server.url>
-                        <test.server.hostname>${test.server.hostname}</test.server.hostname>
-                        <test.server.username>${test.server.username}</test.server.username>
-                        <test.server.password>${test.server.password}</test.server.password>
-                        <jar.executor.server.port>${http.port}</jar.executor.server.port>
-                        <jar.executor.vm.options>${jar.executor.vm.options}</jar.executor.vm.options>
-                        <jar.executor.jar.folder>${project.basedir}/target/dependency</jar.executor.jar.folder>
-                        <jar.executor.jar.name.regexp>org.apache.sling.launchpad.*jar$</jar.executor.jar.name.regexp>
-                        <jar.executor.work.folder>${jar.executor.work.folder}</jar.executor.work.folder>
-                        <jar.executor.jar.options>${jar.executor.jar.options}</jar.executor.jar.options>
-                        <additional.bundles.path>${project.basedir}/target,${project.basedir}/target/sling/additional-bundles</additional.bundles.path>
-                        <keepJarRunning>${keepJarRunning}</keepJarRunning>
+                        <launchpad.http.server.url>http://localhost:${http.port}</launchpad.http.server.url>
                         <server.ready.timeout.seconds>60</server.ready.timeout.seconds>
-                        <sling.testing.timeout.multiplier>${sling.testing.timeout.multiplier}</sling.testing.timeout.multiplier>
-                        <server.ready.path.1>/:script src="system/sling.js"</server.ready.path.1>
-                        <server.ready.path.2>/.explorer.html:href="/libs/sling/explorer/css/explorer.css"</server.ready.path.2>
-                        <server.ready.path.3>/sling-test/sling/sling-test.html:Sling client library tests</server.ready.path.3>
-                        <start.bundles.timeout.seconds>30</start.bundles.timeout.seconds>
-                        <bundle.install.timeout.seconds>20</bundle.install.timeout.seconds>
-                        
-                        <!-- 
-                            Define additional bundles to install by specifying the beginning of their artifact name.
-                            The bundles are installed in lexical order of these property names.
-                            All bundles must be listed as dependencies in this pom, or they won't be installed. 
-                        -->
-                        <sling.additional.bundle.1>org.apache.sling.junit.core</sling.additional.bundle.1>
-                        <sling.additional.bundle.3>org.apache.sling.commons.johnzon</sling.additional.bundle.3>
-                        <sling.additional.bundle.4>commons-lang3</sling.additional.bundle.4>
-                        <sling.additional.bundle.10>org.apache.sling.models.api</sling.additional.bundle.10>
-                        <sling.additional.bundle.11>org.apache.sling.models.impl</sling.additional.bundle.11>
-                        <sling.additional.bundle.12>org.apache.sling.models.jacksonexporter</sling.additional.bundle.12>
-                        <sling.additional.bundle.13>jackson-annotations</sling.additional.bundle.13>
-                        <sling.additional.bundle.14>jackson-core</sling.additional.bundle.14>
-                        <sling.additional.bundle.15>jackson-databind</sling.additional.bundle.15>
-                        <sling.additional.bundle.16>commons-lang3</sling.additional.bundle.16>
-                        <sling.additional.bundle.17>${project.build.finalName}.jar</sling.additional.bundle.17>
+                        <server.ready.path.1>/starter/index.html:Getting Started</server.ready.path.1>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -285,43 +181,60 @@
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <artifactId>osgi.cmpn</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- OSGi annotations -->
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.component.annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.metatype.annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.servlets.annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Additional bundles needed by the Sling instance under test -->
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.junit.core</artifactId>
-            <version>1.0.26</version>
+            <version>1.0.28</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.rules</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.junit.teleporter</artifactId>
-            <version>1.0.12</version>
+            <version>1.0.20</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.apache.sling</groupId>
-          <artifactId>org.apache.sling.commons.johnzon</artifactId>
-          <version>1.0.0</version>
-          <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.engine</artifactId>
-            <version>2.2.0</version>
+            <version>2.6.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -333,7 +246,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.impl</artifactId>
-            <version>1.4.11-SNAPSHOT</version>
+            <version>1.4.17-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -342,83 +255,58 @@
             <version>1.0.9-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- actual dependencies -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.3.2</version>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.3.2</version>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>2.3.2</version>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.api</artifactId>
+            <version>2.18.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.8.1</version>
             <scope>provided</scope>
         </dependency>
-
-        <!-- not part of launchpad 7 (see SLING-4710) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.9.7</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-atinject_1.0_spec</artifactId>
             <version>1.0</version>
             <scope>provided</scope>
         </dependency>
-        
-        <!-- actual dependencies -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.jcr</groupId>
-            <artifactId>jcr</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.api</artifactId>
-            <version>2.4.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.5</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.launchpad</artifactId>
-            <version>8</version>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
-            <version>1.6.6</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <!-- This dependency is not actually used within Sling. It's used for ModelWithOptionalImport test case to test a model with a class that is not resolved. -->
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
@@ -426,6 +314,7 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
     <profiles>
         <profile>
             <id>debug-remote-process</id>
@@ -440,4 +329,5 @@
             </properties>
         </profile>
     </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
                 <configuration>
                     <systemPropertyVariables>
                         <launchpad.http.server.url>http://localhost:${http.port}</launchpad.http.server.url>
-                        <server.ready.timeout.seconds>60</server.ready.timeout.seconds>
+                        <server.ready.timeout.seconds>120</server.ready.timeout.seconds>
                         <server.ready.path.1>/starter/index.html:Getting Started</server.ready.path.1>
                     </systemPropertyVariables>
                 </configuration>

--- a/src/main/java/org/apache/sling/models/it/delegate/request/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/delegate/request/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+@Version("1.0")
+package org.apache.sling.models.it.delegate.request;
 
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/delegate/resource/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/delegate/resource/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+@Version("1.0")
+package org.apache.sling.models.it.delegate.resource;
 
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/exporter/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/exporter/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+@Version("1.0")
+package org.apache.sling.models.it.exporter;
 
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/implpicker/CustomLastImplementationPicker.java
+++ b/src/main/java/org/apache/sling/models/it/implpicker/CustomLastImplementationPicker.java
@@ -18,23 +18,20 @@
  */
 package org.apache.sling.models.it.implpicker;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.spi.ImplementationPicker;
-import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.propertytypes.ServiceRanking;
 
 /**
  * This is a curious {@link ImplementationPicker} implementation for integration test
  * that picks the last implementation if the resource has the name "custom";
  */
-@Component
-@Service
-@Property(name = Constants.SERVICE_RANKING, intValue = 100)
+@Component(service = ImplementationPicker.class)
+@ServiceRanking(100)
 public class CustomLastImplementationPicker implements ImplementationPicker {
-    
+
     public static final String CUSTOM_NAME = "custom";
 
     public Class<?> pick(Class<?> adapterType, Class<?>[] implementationsTypes, Object adaptable) {
@@ -43,5 +40,5 @@ public class CustomLastImplementationPicker implements ImplementationPicker {
         }
         return null;
     }
-    
+
 }

--- a/src/main/java/org/apache/sling/models/it/implpicker/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/implpicker/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+@Version("1.0")
+package org.apache.sling.models.it.implpicker;
 
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/models/implextend/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/models/implextend/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+@Version("1.0")
+package org.apache.sling.models.it.models.implextend;
 
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/models/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/models/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+@Version("1.0")
+package org.apache.sling.models.it.models;
 
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/rtbound/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/rtbound/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+@Version("1.0")
+package org.apache.sling.models.it.rtbound;
 
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/rtboundpicker/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/rtboundpicker/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+@Version("1.0")
+package org.apache.sling.models.it.rtboundpicker;
 
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/services/TestBindingsValuesProvider.java
+++ b/src/main/java/org/apache/sling/models/it/services/TestBindingsValuesProvider.java
@@ -20,13 +20,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
 
-@Component
-@Service(value = Map.class)
-@Property(name = "javax.script.name", value = "*")
+@Component(service = Map.class, property = {
+    "javax.script.name=*"
+})
 public class TestBindingsValuesProvider extends HashMap<String, Object> {
 
     public TestBindingsValuesProvider() {

--- a/src/main/java/org/apache/sling/models/it/services/TestResourceDecorator.java
+++ b/src/main/java/org/apache/sling/models/it/services/TestResourceDecorator.java
@@ -18,17 +18,15 @@ package org.apache.sling.models.it.services;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceDecorator;
 import org.apache.sling.api.resource.ResourceWrapper;
 import org.apache.sling.api.resource.ValueMap;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
-@Component
-@Service
+@Component(service = ResourceDecorator.class)
 public class TestResourceDecorator implements ResourceDecorator {
 
     @Reference

--- a/src/main/java/org/apache/sling/models/it/services/package-info.java
+++ b/src/main/java/org/apache/sling/models/it/services/package-info.java
@@ -14,22 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+@Version("1.0")
 package org.apache.sling.models.it.services;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.osgi.service.component.annotations.Component;
-
-@Component(service = Map.class, property = {
-    "javax.script.name=sling-models-exporter"
-})
-public class AnotherTestBindingsValuesProvider extends HashMap<String, Object> {
-    private static final long serialVersionUID = 1L;
-
-    public AnotherTestBindingsValuesProvider() {
-        super.put("testBindingsObject2", Collections.singletonMap("name2", "value2"));
-    }
-
-}
+import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/models/it/servlets/PathBoundServlet.java
+++ b/src/main/java/org/apache/sling/models/it/servlets/PathBoundServlet.java
@@ -18,15 +18,18 @@ package org.apache.sling.models.it.servlets;
 
 import java.io.IOException;
 
+import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 
-import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.models.it.models.RequestSelfModel;
+import org.apache.sling.servlets.annotations.SlingServletPaths;
+import org.osgi.service.component.annotations.Component;
 
-@SlingServlet(paths = "/apps/rtpickerrequest")
+@Component(service = Servlet.class)
+@SlingServletPaths("/apps/rtpickerrequest")
 public class PathBoundServlet extends SlingSafeMethodsServlet {
 
     @Override
@@ -34,4 +37,5 @@ public class PathBoundServlet extends SlingSafeMethodsServlet {
         RequestSelfModel model = request.adaptTo(RequestSelfModel.class);
         response.setStatus(200);
     }
+
 }

--- a/src/test/java/org/apache/sling/models/testing/DecoratedIT.java
+++ b/src/test/java/org/apache/sling/models/testing/DecoratedIT.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;

--- a/src/test/java/org/apache/sling/models/testing/ImplementsExtendsIT.java
+++ b/src/test/java/org/apache/sling/models/testing/ImplementsExtendsIT.java
@@ -24,7 +24,7 @@ import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;

--- a/src/test/java/org/apache/sling/models/testing/InjectorSpecificAnnotationIT.java
+++ b/src/test/java/org/apache/sling/models/testing/InjectorSpecificAnnotationIT.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;

--- a/src/test/java/org/apache/sling/models/testing/ModelFactorySimpleIT.java
+++ b/src/test/java/org/apache/sling/models/testing/ModelFactorySimpleIT.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;

--- a/src/test/java/org/apache/sling/models/testing/ServiceInjectionWithDifferentRankingIT.java
+++ b/src/test/java/org/apache/sling/models/testing/ServiceInjectionWithDifferentRankingIT.java
@@ -29,7 +29,7 @@ import java.util.Hashtable;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;

--- a/src/test/java/org/apache/sling/models/testing/SimpleIT.java
+++ b/src/test/java/org/apache/sling/models/testing/SimpleIT.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertSame;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;

--- a/src/test/java/org/apache/sling/models/testing/ViaIT.java
+++ b/src/test/java/org/apache/sling/models/testing/ViaIT.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import javax.jcr.Node;
 import javax.jcr.Session;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.sling.api.adapter.AdapterManager;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;

--- a/src/test/java/org/apache/sling/models/testing/exporter/ExporterIT.java
+++ b/src/test/java/org/apache/sling/models/testing/exporter/ExporterIT.java
@@ -29,8 +29,8 @@ import java.util.TimeZone;
 import javax.json.Json;
 import javax.json.JsonObject;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.time.FastDateFormat;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.sling.api.SlingConstants;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -68,7 +68,7 @@ public class ExporterIT {
     private final String interfaceRequestComponentPath = "/content/exp-request/interfaceComponent";
     private Calendar testDate;
 
-    private Format dateFormat = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private Format dateFormat = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZ", TimeZone.getTimeZone("UTC"));
 
     @Before
     public void setup() throws Exception {

--- a/src/test/java/org/apache/sling/models/testing/helper/FakeRequest.java
+++ b/src/test/java/org/apache/sling/models/testing/helper/FakeRequest.java
@@ -20,17 +20,27 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
 
 public class FakeRequest implements HttpServletRequest {
 
@@ -313,5 +323,81 @@ public class FakeRequest implements HttpServletRequest {
     @Override
     public int getLocalPort() {
         return 0;
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+            throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
+    }
+
+    @Override
+    public String changeSessionId() {
+        return null;
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+        return false;
+    }
+
+    @Override
+    public void login(String username, String password) throws ServletException {
+
+    }
+
+    @Override
+    public void logout() throws ServletException {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+        return null;
     }
 }

--- a/src/test/java/org/apache/sling/models/testing/helper/FakeResponse.java
+++ b/src/test/java/org/apache/sling/models/testing/helper/FakeResponse.java
@@ -19,6 +19,7 @@ package org.apache.sling.models.testing.helper;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.Locale;
 
 import javax.servlet.ServletOutputStream;
@@ -197,5 +198,25 @@ public class FakeResponse implements HttpServletResponse {
 
     public int getStatus() {
         return status;
+    }
+
+    @Override
+    public void setContentLengthLong(long len) {
+
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        return null;
     }
 }

--- a/src/test/java/org/apache/sling/models/testing/rtbound/FakeRequest.java
+++ b/src/test/java/org/apache/sling/models/testing/rtbound/FakeRequest.java
@@ -20,15 +20,26 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.request.RequestDispatcherOptions;
@@ -396,4 +407,86 @@ public class FakeRequest implements SlingHttpServletRequest {
     public <AdapterType> AdapterType adaptTo(Class<AdapterType> aClass) {
         return null;
     }
+
+    @Override
+    public String changeSessionId() {
+        return null;
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+        return false;
+    }
+
+    @Override
+    public void login(String username, String password) throws ServletException {
+
+    }
+
+    @Override
+    public void logout() throws ServletException {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        return 0;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+            throws IllegalStateException {
+        return null;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return null;
+    }
+
+    @Override
+    public List<RequestParameter> getRequestParameterList() {
+        return null;
+    }
+
 }

--- a/src/test/provisioning/sling-models-jacksonexporter.txt
+++ b/src/test/provisioning/sling-models-jacksonexporter.txt
@@ -1,0 +1,24 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+# must be the same feature name as the feature defined in slingstart to allow merging
+[feature name=models-jacksonexporter]
+
+[artifacts]
+  org.apache.sling/org.apache.sling.models.jacksonexporter

--- a/src/test/provisioning/sling.txt
+++ b/src/test/provisioning/sling.txt
@@ -1,0 +1,37 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+#
+
+# must be the same feature name as the feature defined in slingstart to allow merging
+[feature name=sling]
+
+[artifacts]
+    org.apache.sling/org.apache.sling.starter/11/slingstart
+
+    # Use versions as defined in POM
+    org.apache.sling/org.apache.sling.models.api
+    org.apache.sling/org.apache.sling.models.impl
+
+    # Additional test bundles
+    org.apache.sling/org.apache.sling.junit.core
+    org.apache.sling/org.apache.sling.models.integration-tests
+
+[configurations]
+    # Allow login administrative for org.apache.sling.junit.core
+    org.apache.sling.jcr.base.internal.LoginAdminWhitelist
+        whitelist.bundles.regexp="org\.apache\.sling\.junit\.core"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-10954

with this we can use either java 8 or java 11, and the integration tests are running against Sling 11

it's still using slingstart-maven-plugin, but this works quite elegant. i hat do combine the different approaches we used in the past to make sure the integration tests are waiting until sling is fully started up. luckily enough, the old ways used in sling 8 still work in sling 11 with the slingstart-maven-plugin, with a little tweaks.

in a separate ticket/task we could evaluate switching to feature model - but i want to test against sling 11 anyway and not necessary against current Sling 12-SNAPSHOT to ensure a good deal of backward compatibility (but dropping compatibility with Sling 8).