### PR TITLE
SLING-11133: add IT coverage for caching multiple adapter types

### DIFF
--- a/src/main/java/org/apache/sling/models/it/delegate/viaoriginalresource/models/B1Impl.java
+++ b/src/main/java/org/apache/sling/models/it/delegate/viaoriginalresource/models/B1Impl.java
@@ -28,7 +28,8 @@ import org.apache.sling.models.it.delegate.viaoriginalresource.B1;
 @Model(
     adaptables = { SlingHttpServletRequest.class, Resource.class },
     adapters = { B1.class, B.class },
-    resourceType = "delegate/nestedrtbound/specific"
+    resourceType = "delegate/nestedrtbound/specific",
+    cache = true
 )
 public class B1Impl implements B1 {
 

--- a/src/main/java/org/apache/sling/models/it/delegate/viaoriginalresource/models/BImpl.java
+++ b/src/main/java/org/apache/sling/models/it/delegate/viaoriginalresource/models/BImpl.java
@@ -24,7 +24,8 @@ import org.apache.sling.models.it.delegate.viaoriginalresource.B;
 @Model(
     adaptables = { SlingHttpServletRequest.class, Resource.class },
     adapters = { B.class },
-    resourceType = "delegate/nestedrtbound/generic"
+    resourceType = "delegate/nestedrtbound/generic",
+    cache = true
 )
 public class BImpl implements B {
 }

--- a/src/test/java/org/apache/sling/models/testing/delegate/viaoriginalresource/ViaOriginalResourceDelegationIT.java
+++ b/src/test/java/org/apache/sling/models/testing/delegate/viaoriginalresource/ViaOriginalResourceDelegationIT.java
@@ -104,6 +104,8 @@ public class ViaOriginalResourceDelegationIT {
             assertTrue(((A1Impl) model).other instanceof B1Impl);
             assertTrue(((A1Impl) model).delegate instanceof AImpl);
             assertTrue(((AImpl) ((A1Impl) model).delegate).other instanceof B1Impl);
+            // Since SLING-11133 and cache = true
+            assertSame(((A1Impl) model).other,((AImpl) ((A1Impl) model).delegate).other);
         }
     }
 
@@ -128,6 +130,8 @@ public class ViaOriginalResourceDelegationIT {
             assertTrue(((A1Impl) model).other instanceof B1Impl);
             assertTrue(((A1Impl) model).delegate instanceof AImpl);
             assertTrue(((AImpl) ((A1Impl) model).delegate).other instanceof B1Impl);
+            // Since SLING-11133 and cache = true
+            assertSame(((A1Impl) model).other,((AImpl) ((A1Impl) model).delegate).other);
         }
     }
 }

--- a/src/test/java/org/apache/sling/models/testing/rtbound/FakeRequest.java
+++ b/src/test/java/org/apache/sling/models/testing/rtbound/FakeRequest.java
@@ -22,6 +22,7 @@ import java.io.UnsupportedEncodingException;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -54,6 +55,7 @@ import org.jetbrains.annotations.NotNull;
 public class FakeRequest implements SlingHttpServletRequest {
 
     private final Resource resource;
+    private final Map<String, Object> attributes = new HashMap<>();
 
     public FakeRequest(Resource r) {
         this.resource = r;
@@ -266,7 +268,7 @@ public class FakeRequest implements SlingHttpServletRequest {
 
     @Override
     public Object getAttribute(String s) {
-        return null;
+        return attributes.get(s);
     }
 
     @Override
@@ -356,7 +358,7 @@ public class FakeRequest implements SlingHttpServletRequest {
 
     @Override
     public void setAttribute(String s, Object o) {
-
+        attributes.put(s, o);
     }
 
     @Override


### PR DESCRIPTION
For details of the implementation see https://github.com/apache/sling-org-apache-sling-models-impl/pull/35